### PR TITLE
add timelimit

### DIFF
--- a/filling_solver/src/FillingSolver.java
+++ b/filling_solver/src/FillingSolver.java
@@ -14,12 +14,14 @@ import javax.imageio.ImageIO;
 
 public class FillingSolver {
 
+	private static final long NO_TIME_LIMIT = -1;
 	static final Rational MAX_SIZE = new Rational(BigInteger.valueOf(1000), BigInteger.valueOf(999));
-//	static final Rational MAX_SIZE = new Rational(BigInteger.valueOf(14), BigInteger.valueOf(10));
+	//	static final Rational MAX_SIZE = new Rational(BigInteger.valueOf(14), BigInteger.valueOf(10));
 	PartsDecomposer decomposer;
 	int[] partsUsed;
 	int maxBitLength;
 	ArrayList<HashSet<Integer>> usedHash = new ArrayList<>();
+	long limitTime;
 
 	FillingSolver(PartsDecomposer decomposer) {
 		this.decomposer = decomposer;
@@ -30,7 +32,12 @@ public class FillingSolver {
 		maxBitLength += 2;
 	}
 
-	void solve() {
+	/**
+	 * @param timelimitMs time limit in microseconds, or 0 (no limit)
+	 */
+	void solve(int timelimitMs) {
+		limitTime = timelimitMs == 0 ? NO_TIME_LIMIT : System.currentTimeMillis() + timelimitMs;
+
 		ArrayList<Part> parts = decomposer.parts;
 		Collections.sort(parts, (Part l, Part r) -> {
 			return r.area.compareTo(l.area);
@@ -61,6 +68,7 @@ public class FillingSolver {
 		//				System.out.println(cur.envelop);
 		//				System.out.println(cur.xmin + " " + cur.xmax + " " + cur.ymin + " " + cur.ymax);
 		//				System.out.println();
+		if (limitTime != NO_TIME_LIMIT && System.currentTimeMillis() > limitTime) return null;
 		while (usedHash.size() <= cur.envelop.size()) {
 			usedHash.add(new HashSet<Integer>());
 		}

--- a/filling_solver/src/Main.java
+++ b/filling_solver/src/Main.java
@@ -1,7 +1,10 @@
 import java.util.Arrays;
 
 public class Main {
+	static int timeOutMs = 0;
+
 	public static void main(String[] args) {
+		parseOptions(args);
 		Runtime.getRuntime().addShutdownHook(new Thread(() -> System.err.println("Run Shutdown Hook.")));
 		PartsDecomposer decomposer = new PartsDecomposer();
 		decomposer.readInput(System.in);
@@ -12,6 +15,16 @@ public class Main {
 		System.err.println(Arrays.toString(decomposer.edges));
 		System.err.println(decomposer.parts);
 		FillingSolver solver = new FillingSolver(decomposer);
-		solver.solve();
+		solver.solve(timeOutMs);
 	}
+
+	static void parseOptions(String[] args) {
+		for (int i = 0; i < args.length; ++i) {
+			if (args[i].equals("-t") || args[i].equals("--timelimit")) {
+				timeOutMs = Integer.parseInt(args[i + 1]);
+				++i;
+			}
+		}
+	}
+
 }


### PR DESCRIPTION
-t または --timelimit で、ソルバのタイムアウト時間（ms単位）を渡せるようにしました

15秒で終了させる例：

```
$ java -jar FillingSolver.jar -t 15000 < problem.txt > result.txt
```
